### PR TITLE
Allow the use of custom login templates when default options are not suitable

### DIFF
--- a/client/common/login.js
+++ b/client/common/login.js
@@ -1,5 +1,11 @@
 Template.mfAdminLogin.helpers({
   serviceTemplate: function () {
+    var loginLayoutTemplate = Admin.config.get('loginLayoutTemplate');
+
+    if (loginLayoutTemplate){
+      return loginLayoutTemplate;
+    }
+
     if (Package['useraccounts:bootstrap']) {
       return 'mfAdminLoginUseraccountsBootstrap'
     };
@@ -7,6 +13,8 @@ Template.mfAdminLogin.helpers({
     if (Package['accounts-ui']) {
       return 'mfAdminLoginAccountsUI';
     }
+
+    throw new Error('Missing template for login page.');
   },
 
   data: function () {

--- a/client/common/login.js
+++ b/client/common/login.js
@@ -24,8 +24,9 @@ Template.mfAdminLogin.helpers({
   }
 });
 
-Template.mfAdminLoginAccountsUI.onCreated(function () {
+Template.mfAdminLogin.onCreated(function () {
   this.autorun(function () {
+    var user = Meteor.user();
     if (Admin.isAdmin(Meteor.userId())) {
       Admin.go('/');
     }

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -3,6 +3,7 @@ Admin = {
   config: new ReactiveDict()
 };
 
+Admin.config.setDefault('loginLayoutTemplate', undefined);
 Admin.config.setDefault('layoutTemplate', 'mfAdminLayout');
 Admin.config.setDefault('name', 'Admin');
 


### PR DESCRIPTION
Hello,

thanks for this package. I was going to create something similar for a project I am working on, but I thought it is great if I can use this even if it is at a preliminary stage. 

I did some changes to login templates. I introduced a config var loginLayoutTemplate to specify a template to use for login page. This is intended in the case when one doesn't want to use accounts-ui or useraccounts packages. In addition I added an exception when no login page template is defined (mainly for debug reasons).
